### PR TITLE
Remove layers before setting reference to nil

### DIFF
--- a/EZRatingView/EZRatingView.m
+++ b/EZRatingView/EZRatingView.m
@@ -183,7 +183,9 @@ NSString *const EZMarkerHighlightColorKey = @"EZMarkerHighlightColorKey";
     _markerDict = markerDict;
     _highlightImage = nil;
     _maskImage = nil;
+    [_highlightLayer removeFromSuperlayer];
     _highlightLayer = nil;
+    [_maskLayer removeFromSuperlayer];
     _maskLayer = nil;
     [self setNeedsDisplay];
 }


### PR DESCRIPTION
Every time a new marker dictionary is set, layer references are set to nil, but the layers don't get removed from super layer. This causes the `highlightLayer` and `maskLayer` to be overwritten, specially if rating character, image or font size attributes are modified. Removing these layers from its super layer before setting reference to nil will fix the issue and perform cleanup as intended. 